### PR TITLE
fix(#370): Only apply reverse/forward min if the actual input is NOT …

### DIFF
--- a/src/v3xctrl_control/apps/streamer.py
+++ b/src/v3xctrl_control/apps/streamer.py
@@ -183,10 +183,11 @@ def control_handler(message: Control, address: Address) -> None:
         raw_steering = values['steering']
 
         # Determine throttle pulse forward or reverse
+        scaled_throttle = raw_throttle * forward_multiplier
         if raw_throttle > 0:
             scaled_throttle = raw_throttle * forward_multiplier
             throttle_value = map_range(scaled_throttle, 0, 1, forward_min, throttle_max)
-        else:
+        elif raw_throttle < 0:
             scaled_throttle = raw_throttle * reverse_multiplier
             throttle_value = map_range(scaled_throttle, -1, 0, throttle_min, reverse_min)
 


### PR DESCRIPTION
…0 (at center)