### PR TITLE
fix(#507): Replace cap_net_bind_service with sysctl for privileged po…

### DIFF
--- a/build/packages/v3xctrl/DEBIAN/postinst
+++ b/build/packages/v3xctrl/DEBIAN/postinst
@@ -16,8 +16,7 @@ chown $USER:$USER "/data/config"
 chown $USER:$USER "/data/config/config.json"
 chmod 640 "/data/config/config.json"
 
-# Grant capability to bind to privileged ports (port 80)
-setcap 'cap_net_bind_service=+ep' /opt/v3xctrl-python/bin/python3.11
+setcap -r /opt/v3xctrl-python/bin/python3.11 2>/dev/null || true
 
 if command -v systemctl >/dev/null 2>&1; then
   # Disable services that we do not need or are handled by other services

--- a/build/packages/v3xctrl/etc/sysctl.d/99-v3xctrl-ports.conf
+++ b/build/packages/v3xctrl/etc/sysctl.d/99-v3xctrl-ports.conf
@@ -1,0 +1,1 @@
+net.ipv4.ip_unprivileged_port_start=80


### PR DESCRIPTION
…rt binding

cap_net_bind_service on the Python binary caused the kernel to set AT_SECURE, which made glibc's secure_getenv() return NULL. This silently broke all libcamera environment variables (e.g. LIBCAMERA_RPI_CONFIG_FILE, LIBCAMERA_LOG_LEVELS) since libcamera reads them via secure_getenv().

Replaced with sysctl net.ipv4.ip_unprivileged_port_start=80, which allows unprivileged port binding without triggering AT_SECURE. The postinst now also removes any previously set file capabilities on upgrade.