### PR TITLE
fix(#541): Add inversion to all steering options on android

### DIFF
--- a/android/app/src/main/java/com/v3xctrl/viewer/data/SettingsDataStore.kt
+++ b/android/app/src/main/java/com/v3xctrl/viewer/data/SettingsDataStore.kt
@@ -55,7 +55,11 @@ data class ControlSettings(
     val gamepadReverseSign: Int = 1,
     val gamepadSteeringInvert: Boolean = false,
     val gamepadThrottleInvert: Boolean = false,
-    val gamepadReverseInvert: Boolean = false
+    val gamepadReverseInvert: Boolean = false,
+    val touchSteeringInvert: Boolean = false,
+    val touchThrottleInvert: Boolean = false,
+    val motionSteeringInvert: Boolean = false,
+    val motionThrottleInvert: Boolean = false
 )
 
 class SettingsDataStore(private val context: Context) {
@@ -101,6 +105,11 @@ class SettingsDataStore(private val context: Context) {
         private val GAMEPAD_STEERING_INVERT = booleanPreferencesKey("gamepad_steering_invert")
         private val GAMEPAD_THROTTLE_INVERT = booleanPreferencesKey("gamepad_throttle_invert")
         private val GAMEPAD_REVERSE_INVERT = booleanPreferencesKey("gamepad_reverse_invert")
+
+        private val TOUCH_STEERING_INVERT = booleanPreferencesKey("touch_steering_invert")
+        private val TOUCH_THROTTLE_INVERT = booleanPreferencesKey("touch_throttle_invert")
+        private val MOTION_STEERING_INVERT = booleanPreferencesKey("motion_steering_invert")
+        private val MOTION_THROTTLE_INVERT = booleanPreferencesKey("motion_throttle_invert")
     }
 
     val networkSettings: Flow<NetworkSettings> = context.dataStore.data.map { prefs ->
@@ -156,7 +165,11 @@ class SettingsDataStore(private val context: Context) {
             gamepadReverseSign = prefs[GAMEPAD_REVERSE_SIGN] ?: defaults.gamepadReverseSign,
             gamepadSteeringInvert = prefs[GAMEPAD_STEERING_INVERT] ?: defaults.gamepadSteeringInvert,
             gamepadThrottleInvert = prefs[GAMEPAD_THROTTLE_INVERT] ?: defaults.gamepadThrottleInvert,
-            gamepadReverseInvert = prefs[GAMEPAD_REVERSE_INVERT] ?: defaults.gamepadReverseInvert
+            gamepadReverseInvert = prefs[GAMEPAD_REVERSE_INVERT] ?: defaults.gamepadReverseInvert,
+            touchSteeringInvert = prefs[TOUCH_STEERING_INVERT] ?: defaults.touchSteeringInvert,
+            touchThrottleInvert = prefs[TOUCH_THROTTLE_INVERT] ?: defaults.touchThrottleInvert,
+            motionSteeringInvert = prefs[MOTION_STEERING_INVERT] ?: defaults.motionSteeringInvert,
+            motionThrottleInvert = prefs[MOTION_THROTTLE_INVERT] ?: defaults.motionThrottleInvert
         )
     }
 
@@ -210,6 +223,10 @@ class SettingsDataStore(private val context: Context) {
             prefs[GAMEPAD_STEERING_INVERT] = settings.gamepadSteeringInvert
             prefs[GAMEPAD_THROTTLE_INVERT] = settings.gamepadThrottleInvert
             prefs[GAMEPAD_REVERSE_INVERT] = settings.gamepadReverseInvert
+            prefs[TOUCH_STEERING_INVERT] = settings.touchSteeringInvert
+            prefs[TOUCH_THROTTLE_INVERT] = settings.touchThrottleInvert
+            prefs[MOTION_STEERING_INVERT] = settings.motionSteeringInvert
+            prefs[MOTION_THROTTLE_INVERT] = settings.motionThrottleInvert
         }
     }
 }

--- a/android/app/src/main/java/com/v3xctrl/viewer/input/MotionController.kt
+++ b/android/app/src/main/java/com/v3xctrl/viewer/input/MotionController.kt
@@ -24,6 +24,8 @@ class MotionController(
     steeringDeg: Float = 45f,
     forwardDeg: Float = 45f,
     backwardDeg: Float = 45f,
+    private val steeringInvert: Boolean = false,
+    private val throttleInvert: Boolean = false,
     private val deadZone: Float = 0.1f
 ) : SensorEventListener {
 
@@ -112,8 +114,11 @@ class MotionController(
         // Steering: left/right tilt
         val rawSteering = (deltaRoll / steeringRad).coerceIn(-1f, 1f)
 
-        controlState.throttle = applyDeadZone(rawThrottle, deadZone)
-        controlState.steering = applyDeadZone(rawSteering, deadZone)
+        val steeringMul = if (steeringInvert) -1f else 1f
+        val throttleMul = if (throttleInvert) -1f else 1f
+
+        controlState.throttle = applyDeadZone(rawThrottle * throttleMul, deadZone)
+        controlState.steering = applyDeadZone(rawSteering * steeringMul, deadZone)
     }
 
     override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {

--- a/android/app/src/main/java/com/v3xctrl/viewer/ui/components/TouchControls.kt
+++ b/android/app/src/main/java/com/v3xctrl/viewer/ui/components/TouchControls.kt
@@ -29,6 +29,8 @@ import com.v3xctrl.viewer.input.applyDeadZone
 fun TouchControls(
     controlState: ControlState,
     modifier: Modifier = Modifier,
+    steeringInvert: Boolean = false,
+    throttleInvert: Boolean = false,
     deadZone: Float = 0.1f,
     maxDragPx: Float = 200f
 ) {
@@ -75,7 +77,8 @@ fun TouchControls(
                                             leftTouch = leftTouch?.copy(currentPosition = change.position)
                                             leftTouch?.let { touch ->
                                                 val deltaY = touch.startPosition.y - touch.currentPosition.y
-                                                val normalized = (deltaY / maxDrag).coerceIn(-1f, 1f)
+                                                val throttleMul = if (throttleInvert) -1f else 1f
+                                                val normalized = (deltaY / maxDrag * throttleMul).coerceIn(-1f, 1f)
                                                 controlState.throttle = applyDeadZone(normalized, deadZone)
                                             }
                                         }
@@ -84,7 +87,8 @@ fun TouchControls(
                                             rightTouch = rightTouch?.copy(currentPosition = change.position)
                                             rightTouch?.let { touch ->
                                                 val deltaX = touch.currentPosition.x - touch.startPosition.x
-                                                val normalized = (deltaX / maxDrag).coerceIn(-1f, 1f)
+                                                val steeringMul = if (steeringInvert) -1f else 1f
+                                                val normalized = (deltaX / maxDrag * steeringMul).coerceIn(-1f, 1f)
                                                 controlState.steering = applyDeadZone(normalized, deadZone)
                                             }
                                         }

--- a/android/app/src/main/java/com/v3xctrl/viewer/ui/components/TouchControls.kt
+++ b/android/app/src/main/java/com/v3xctrl/viewer/ui/components/TouchControls.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -40,6 +41,10 @@ fun TouchControls(
     // Track active touches for each zone
     var leftTouch by remember { mutableStateOf<TouchInfo?>(null) }
     var rightTouch by remember { mutableStateOf<TouchInfo?>(null) }
+
+    // Raw (non-inverted) values for visual indicators
+    var rawThrottle by remember { mutableFloatStateOf(0f) }
+    var rawSteering by remember { mutableFloatStateOf(0f) }
 
     Box(
         modifier = modifier
@@ -77,9 +82,10 @@ fun TouchControls(
                                             leftTouch = leftTouch?.copy(currentPosition = change.position)
                                             leftTouch?.let { touch ->
                                                 val deltaY = touch.startPosition.y - touch.currentPosition.y
-                                                val throttleMul = if (throttleInvert) -1f else 1f
-                                                val normalized = (deltaY / maxDrag * throttleMul).coerceIn(-1f, 1f)
-                                                controlState.throttle = applyDeadZone(normalized, deadZone)
+                                                val normalized = (deltaY / maxDrag).coerceIn(-1f, 1f)
+                                                rawThrottle = applyDeadZone(normalized, deadZone)
+                                                val invertMul = if (throttleInvert) -1f else 1f
+                                                controlState.throttle = rawThrottle * invertMul
                                             }
                                         }
 
@@ -87,9 +93,10 @@ fun TouchControls(
                                             rightTouch = rightTouch?.copy(currentPosition = change.position)
                                             rightTouch?.let { touch ->
                                                 val deltaX = touch.currentPosition.x - touch.startPosition.x
-                                                val steeringMul = if (steeringInvert) -1f else 1f
-                                                val normalized = (deltaX / maxDrag * steeringMul).coerceIn(-1f, 1f)
-                                                controlState.steering = applyDeadZone(normalized, deadZone)
+                                                val normalized = (deltaX / maxDrag).coerceIn(-1f, 1f)
+                                                rawSteering = applyDeadZone(normalized, deadZone)
+                                                val invertMul = if (steeringInvert) -1f else 1f
+                                                controlState.steering = rawSteering * invertMul
                                             }
                                         }
                                     }
@@ -100,11 +107,13 @@ fun TouchControls(
                                     when (change.id) {
                                         leftTouch?.id -> {
                                             leftTouch = null
+                                            rawThrottle = 0f
                                             controlState.throttle = 0f
                                         }
 
                                         rightTouch?.id -> {
                                             rightTouch = null
+                                            rawSteering = 0f
                                             controlState.steering = 0f
                                         }
                                     }
@@ -118,8 +127,8 @@ fun TouchControls(
         TouchIndicators(
             leftTouch = leftTouch,
             rightTouch = rightTouch,
-            throttle = controlState.throttle,
-            steering = controlState.steering
+            throttle = rawThrottle,
+            steering = rawSteering
         )
     }
 }

--- a/android/app/src/main/java/com/v3xctrl/viewer/ui/screens/ControlScreen.kt
+++ b/android/app/src/main/java/com/v3xctrl/viewer/ui/screens/ControlScreen.kt
@@ -163,6 +163,36 @@ fun ControlScreen(
                 modifier = Modifier.padding(top = 8.dp)
             )
 
+            // -- Touch invert checkboxes --
+            if (settings.controlMode == "touch") {
+                Spacer(modifier = Modifier.height(12.dp))
+                InvertRow(
+                    label = "${stringResource(R.string.control_invert)} ${stringResource(R.string.control_steering_scale).lowercase()}",
+                    checked = settings.touchSteeringInvert,
+                    onCheckedChange = { onSettingsChange(settings.copy(touchSteeringInvert = it)) }
+                )
+                InvertRow(
+                    label = "${stringResource(R.string.control_invert)} ${stringResource(R.string.control_gamepad_throttle).lowercase()}",
+                    checked = settings.touchThrottleInvert,
+                    onCheckedChange = { onSettingsChange(settings.copy(touchThrottleInvert = it)) }
+                )
+            }
+
+            // -- Motion invert checkboxes --
+            if (settings.controlMode == "motion") {
+                Spacer(modifier = Modifier.height(12.dp))
+                InvertRow(
+                    label = "${stringResource(R.string.control_invert)} ${stringResource(R.string.control_steering_scale).lowercase()}",
+                    checked = settings.motionSteeringInvert,
+                    onCheckedChange = { onSettingsChange(settings.copy(motionSteeringInvert = it)) }
+                )
+                InvertRow(
+                    label = "${stringResource(R.string.control_invert)} ${stringResource(R.string.control_gamepad_throttle).lowercase()}",
+                    checked = settings.motionThrottleInvert,
+                    onCheckedChange = { onSettingsChange(settings.copy(motionThrottleInvert = it)) }
+                )
+            }
+
             // -- Gamepad device selector, calibration, and live display --
             if (settings.controlMode == "gamepad") {
                 Spacer(modifier = Modifier.height(16.dp))
@@ -637,6 +667,7 @@ private fun AxisIndicator(
 private fun InvertRow(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
+    label: String? = null,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -648,7 +679,7 @@ private fun InvertRow(
             onCheckedChange = onCheckedChange
         )
         Text(
-            text = stringResource(R.string.control_invert),
+            text = label ?: stringResource(R.string.control_invert),
             style = MaterialTheme.typography.bodySmall
         )
     }

--- a/android/app/src/main/java/com/v3xctrl/viewer/ui/screens/ControlScreen.kt
+++ b/android/app/src/main/java/com/v3xctrl/viewer/ui/screens/ControlScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
@@ -31,6 +30,7 @@ import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -163,31 +163,35 @@ fun ControlScreen(
                 modifier = Modifier.padding(top = 8.dp)
             )
 
-            // -- Touch invert checkboxes --
+            // -- Touch invert switches --
             if (settings.controlMode == "touch") {
                 Spacer(modifier = Modifier.height(12.dp))
                 InvertRow(
                     label = "${stringResource(R.string.control_invert)} ${stringResource(R.string.control_steering_scale).lowercase()}",
+                    description = stringResource(R.string.control_invert_steering_desc),
                     checked = settings.touchSteeringInvert,
                     onCheckedChange = { onSettingsChange(settings.copy(touchSteeringInvert = it)) }
                 )
                 InvertRow(
                     label = "${stringResource(R.string.control_invert)} ${stringResource(R.string.control_gamepad_throttle).lowercase()}",
+                    description = stringResource(R.string.control_invert_throttle_desc),
                     checked = settings.touchThrottleInvert,
                     onCheckedChange = { onSettingsChange(settings.copy(touchThrottleInvert = it)) }
                 )
             }
 
-            // -- Motion invert checkboxes --
+            // -- Motion invert switches --
             if (settings.controlMode == "motion") {
                 Spacer(modifier = Modifier.height(12.dp))
                 InvertRow(
                     label = "${stringResource(R.string.control_invert)} ${stringResource(R.string.control_steering_scale).lowercase()}",
+                    description = stringResource(R.string.control_invert_steering_desc),
                     checked = settings.motionSteeringInvert,
                     onCheckedChange = { onSettingsChange(settings.copy(motionSteeringInvert = it)) }
                 )
                 InvertRow(
                     label = "${stringResource(R.string.control_invert)} ${stringResource(R.string.control_gamepad_throttle).lowercase()}",
+                    description = stringResource(R.string.control_invert_throttle_desc),
                     checked = settings.motionThrottleInvert,
                     onCheckedChange = { onSettingsChange(settings.copy(motionThrottleInvert = it)) }
                 )
@@ -461,12 +465,14 @@ fun ControlScreen(
 
                         Spacer(modifier = Modifier.height(12.dp))
 
-                        // Live axis indicators with invert checkboxes
+                        // Live axis indicators with invert switches
                         AxisIndicator(
                             label = stringResource(R.string.control_gamepad_steering),
                             value = liveSteering.floatValue
                         )
                         InvertRow(
+                            label = "${stringResource(R.string.control_invert)} ${stringResource(R.string.control_gamepad_steering).lowercase()}",
+                            description = stringResource(R.string.control_invert_steering_desc),
                             checked = settings.gamepadSteeringInvert,
                             onCheckedChange = { onSettingsChange(settings.copy(gamepadSteeringInvert = it)) }
                         )
@@ -477,6 +483,8 @@ fun ControlScreen(
                             centered = false
                         )
                         InvertRow(
+                            label = "${stringResource(R.string.control_invert)} ${stringResource(R.string.control_gamepad_forward).lowercase()}",
+                            description = stringResource(R.string.control_invert_forward_desc),
                             checked = settings.gamepadThrottleInvert,
                             onCheckedChange = { onSettingsChange(settings.copy(gamepadThrottleInvert = it)) }
                         )
@@ -487,6 +495,8 @@ fun ControlScreen(
                             centered = false
                         )
                         InvertRow(
+                            label = "${stringResource(R.string.control_invert)} ${stringResource(R.string.control_gamepad_reverse).lowercase()}",
+                            description = stringResource(R.string.control_invert_reverse_desc),
                             checked = settings.gamepadReverseInvert,
                             onCheckedChange = { onSettingsChange(settings.copy(gamepadReverseInvert = it)) }
                         )
@@ -668,19 +678,31 @@ private fun InvertRow(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     label: String? = null,
+    description: String? = null,
     modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier.padding(start = 72.dp),
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Checkbox(
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label ?: stringResource(R.string.control_invert),
+                style = MaterialTheme.typography.bodyLarge
+            )
+
+            if (description != null) {
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+
+        Switch(
             checked = checked,
             onCheckedChange = onCheckedChange
-        )
-        Text(
-            text = label ?: stringResource(R.string.control_invert),
-            style = MaterialTheme.typography.bodySmall
         )
     }
 }

--- a/android/app/src/main/java/com/v3xctrl/viewer/ui/screens/LandscapeViewer.kt
+++ b/android/app/src/main/java/com/v3xctrl/viewer/ui/screens/LandscapeViewer.kt
@@ -45,6 +45,8 @@ fun LandscapeViewer(
     spectatorMode: Boolean,
     pipelineStartTime: Long,
     osdSettings: OsdSettings = OsdSettings(),
+    touchSteeringInvert: Boolean = false,
+    touchThrottleInvert: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -220,7 +222,9 @@ fun LandscapeViewer(
                 else -> {
                     TouchControls(
                         controlState = controlState,
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.fillMaxSize(),
+                        steeringInvert = touchSteeringInvert,
+                        throttleInvert = touchThrottleInvert
                     )
                 }
             }

--- a/android/app/src/main/java/com/v3xctrl/viewer/ui/screens/ViewerScreen.kt
+++ b/android/app/src/main/java/com/v3xctrl/viewer/ui/screens/ViewerScreen.kt
@@ -94,14 +94,16 @@ fun ViewerScreen(
     val isGamepadMode = controlSettings.controlMode == "gamepad" && !spectatorMode
 
     // Start/stop motion controller based on mode and orientation
-    DisposableEffect(isMotionMode, isLandscape, controlSettings.motionSteeringDeg, controlSettings.motionForwardDeg, controlSettings.motionBackwardDeg) {
+    DisposableEffect(isMotionMode, isLandscape, controlSettings.motionSteeringDeg, controlSettings.motionForwardDeg, controlSettings.motionBackwardDeg, controlSettings.motionSteeringInvert, controlSettings.motionThrottleInvert) {
         if (isMotionMode && isLandscape) {
             val controller = MotionController(
                 context = context,
                 controlState = controlState,
                 steeringDeg = controlSettings.motionSteeringDeg.toFloat(),
                 forwardDeg = controlSettings.motionForwardDeg.toFloat(),
-                backwardDeg = controlSettings.motionBackwardDeg.toFloat()
+                backwardDeg = controlSettings.motionBackwardDeg.toFloat(),
+                steeringInvert = controlSettings.motionSteeringInvert,
+                throttleInvert = controlSettings.motionThrottleInvert
             )
             controller.start()
             motionController = controller
@@ -309,6 +311,8 @@ fun ViewerScreen(
             spectatorMode = spectatorMode,
             pipelineStartTime = pipelineStartTime,
             osdSettings = osdSettings,
+            touchSteeringInvert = controlSettings.touchSteeringInvert,
+            touchThrottleInvert = controlSettings.touchThrottleInvert,
             modifier = modifier
         )
     } else {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -59,6 +59,10 @@
     <string name="control_gamepad_forward">Forward</string>
     <string name="control_gamepad_reverse">Reverse</string>
     <string name="control_invert">Invert</string>
+    <string name="control_invert_steering_desc">Reverse the steering direction</string>
+    <string name="control_invert_throttle_desc">Reverse the throttle direction</string>
+    <string name="control_invert_forward_desc">Reverse the forward axis direction</string>
+    <string name="control_invert_reverse_desc">Reverse the reverse axis direction</string>
 
     <!-- OSD screen -->
     <string name="osd_title">OSD</string>


### PR DESCRIPTION
TODO

* [x] Virtual sticks should not be inverted