### PR TITLE
fix(#646): Disable default modem route

### DIFF
--- a/build/packages/v3xctrl/etc/NetworkManager/dispatcher.d/50-no-default-modem-route
+++ b/build/packages/v3xctrl/etc/NetworkManager/dispatcher.d/50-no-default-modem-route
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Prevent non-wlan interfaces (e.g. RNDIS modem on eth0) from taking the
+# default route unless the user has explicitly configured rndis routing.
+# Without this, NetworkManager gives eth0 a lower metric than wlan0, causing
+# all traffic to route through a modem that may have no internet (no SIM).
+
+INTERFACE="$1"
+ACTION="$2"
+
+if [[ "$INTERFACE" == "wlan0" || "$INTERFACE" == "lo" ]]; then
+    exit 0
+fi
+
+if [[ "$ACTION" == "up" || "$ACTION" == "dhcp4-change" ]]; then
+    ROUTING_MODE="wlan"
+    if [ -f /run/v3xctrl.env ]; then
+        ROUTING_MODE=$(grep -oP '^network_routing=\K.*' /run/v3xctrl.env || echo "wlan")
+    fi
+
+    if [[ "$ROUTING_MODE" != "rndis" ]]; then
+        ip route del default dev "$INTERFACE" 2>/dev/null || true
+    fi
+fi

--- a/build/packages/v3xctrl/etc/NetworkManager/dispatcher.d/50-no-default-modem-route
+++ b/build/packages/v3xctrl/etc/NetworkManager/dispatcher.d/50-no-default-modem-route
@@ -1,10 +1,28 @@
 #!/bin/bash
 
-# Prevent non-wlan interfaces (e.g. RNDIS modem on eth0) from taking the
-# default route or DNS priority unless the user has explicitly configured
-# rndis routing. Without this, NetworkManager gives eth0 a lower metric than
-# wlan0, causing all traffic and DNS to go through a modem that may have no
-# internet (no SIM).
+# NetworkManager dispatcher script to prevent the RNDIS modem (typically eth0)
+# from hijacking the default route and DNS.
+#
+# Why this is needed:
+#   NetworkManager assigns ethernet a lower metric (100) than WiFi (600).
+#   When the modem is plugged in, it gets an IP via DHCP and becomes the
+#   default gateway - even without a SIM card. This breaks all internet
+#   connectivity and DNS resolution because traffic is sent to a modem
+#   with no upstream connection.
+#
+# Why a dispatcher script instead of declarative config:
+#   The ideal fix would be dhcp4-overrides in /boot/firmware/network-config
+#   (use-routes: false, use-dns: false). However, Raspberry Pi Imager
+#   overwrites network-config at flash time, so we cannot control its
+#   contents from the image build. NetworkManager.conf also does not
+#   support ipv4.never-default as a connection default. A dispatcher
+#   script is the only reliable mechanism that survives reflashing.
+#
+# What it does:
+#   - Removes the default route from non-wlan interfaces
+#   - Clears DNS servers from non-wlan interfaces (runtime only, no disk writes)
+#   - Skips both when rndis routing is explicitly configured, since
+#     v3xctrl-route-manager handles routing in that case
 
 INTERFACE="$1"
 ACTION="$2"
@@ -22,8 +40,6 @@ if [[ "$ACTION" == "up" || "$ACTION" == "dhcp4-change" ]]; then
     if [[ "$ROUTING_MODE" != "rndis" ]]; then
         ip route del default dev "$INTERFACE" 2>/dev/null || true
 
-        # Remove DNS servers provided by this interface so wlan0 DNS is used.
-        # NM regenerates resolv.conf from remaining connections.
         CONNECTION=$(nmcli -g GENERAL.CONNECTION device show "$INTERFACE" 2>/dev/null)
         if [ -n "$CONNECTION" ]; then
             nmcli device modify "$INTERFACE" ipv4.dns "" 2>/dev/null || true

--- a/build/packages/v3xctrl/etc/NetworkManager/dispatcher.d/50-no-default-modem-route
+++ b/build/packages/v3xctrl/etc/NetworkManager/dispatcher.d/50-no-default-modem-route
@@ -31,7 +31,7 @@ if [[ "$INTERFACE" == "wlan0" || "$INTERFACE" == "lo" ]]; then
     exit 0
 fi
 
-if [[ "$ACTION" == "up" || "$ACTION" == "dhcp4-change" ]]; then
+if [[ "$ACTION" == "up" || "$ACTION" == "dhcp4-change" || "$ACTION" == "reapply" ]]; then
     ROUTING_MODE="wlan"
     if [ -f /run/v3xctrl.env ]; then
         ROUTING_MODE=$(grep -oP '^network_routing=\K.*' /run/v3xctrl.env || echo "wlan")
@@ -40,10 +40,13 @@ if [[ "$ACTION" == "up" || "$ACTION" == "dhcp4-change" ]]; then
     if [[ "$ROUTING_MODE" != "rndis" ]]; then
         ip route del default dev "$INTERFACE" 2>/dev/null || true
 
-        CONNECTION=$(nmcli -g GENERAL.CONNECTION device show "$INTERFACE" 2>/dev/null)
-        if [ -n "$CONNECTION" ]; then
-            nmcli device modify "$INTERFACE" ipv4.dns "" 2>/dev/null || true
-            nmcli device modify "$INTERFACE" ipv6.dns "" 2>/dev/null || true
+        # Deprioritize DNS from this interface so wlan0 DNS is preferred.
+        # NM default priority is 100; setting higher = lower priority.
+        # Only on initial events, not reapply (which this triggers), to
+        # avoid an infinite loop.
+        if [[ "$ACTION" != "reapply" ]]; then
+            nmcli device modify "$INTERFACE" ipv4.dns-priority 300 2>/dev/null || true
+            nmcli device modify "$INTERFACE" ipv6.dns-priority 300 2>/dev/null || true
         fi
     fi
 fi

--- a/build/packages/v3xctrl/etc/NetworkManager/dispatcher.d/50-no-default-modem-route
+++ b/build/packages/v3xctrl/etc/NetworkManager/dispatcher.d/50-no-default-modem-route
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 # Prevent non-wlan interfaces (e.g. RNDIS modem on eth0) from taking the
-# default route unless the user has explicitly configured rndis routing.
-# Without this, NetworkManager gives eth0 a lower metric than wlan0, causing
-# all traffic to route through a modem that may have no internet (no SIM).
+# default route or DNS priority unless the user has explicitly configured
+# rndis routing. Without this, NetworkManager gives eth0 a lower metric than
+# wlan0, causing all traffic and DNS to go through a modem that may have no
+# internet (no SIM).
 
 INTERFACE="$1"
 ACTION="$2"
@@ -20,5 +21,13 @@ if [[ "$ACTION" == "up" || "$ACTION" == "dhcp4-change" ]]; then
 
     if [[ "$ROUTING_MODE" != "rndis" ]]; then
         ip route del default dev "$INTERFACE" 2>/dev/null || true
+
+        # Remove DNS servers provided by this interface so wlan0 DNS is used.
+        # NM regenerates resolv.conf from remaining connections.
+        CONNECTION=$(nmcli -g GENERAL.CONNECTION device show "$INTERFACE" 2>/dev/null)
+        if [ -n "$CONNECTION" ]; then
+            nmcli device modify "$INTERFACE" ipv4.dns "" 2>/dev/null || true
+            nmcli device modify "$INTERFACE" ipv6.dns "" 2>/dev/null || true
+        fi
     fi
 fi

--- a/build/packages/v3xctrl/usr/bin/v3xctrl-route-manager
+++ b/build/packages/v3xctrl/usr/bin/v3xctrl-route-manager
@@ -41,10 +41,13 @@ fi
 
 echo "Using $PRIMARY_IF as default route interface"
 
-# Find gateway for selected interface
+# Find gateway for selected interface.
+# Check existing default route first, then ask NetworkManager (handles
+# ipv4.never-default connections where no default route exists), and
+# finally infer from the device IP as a last resort.
 GW=$(ip -4 route show default dev "$PRIMARY_IF" | awk '{print $3}' | head -n1 | tr -d '\r\n')
 if [ -z "$GW" ]; then
-  GW=$(ip route | grep "^default.*$PRIMARY_IF" | awk '{print $3}' | head -n1 | tr -d '\r\n')
+  GW=$(nmcli -g IP4.GATEWAY device show "$PRIMARY_IF" 2>/dev/null | tr -d '\r\n')
 fi
 
 if [ -z "$GW" ]; then


### PR DESCRIPTION
@Noctaro this should disable the default for the modem on initial startup.

Please check with ip route again during setup, and after setup. Once you switch to rndis vie config, that switch should be working though.