### PR TITLE
fix(#667): Generate version based on base version from DEBIAN file an…

### DIFF
--- a/.github/workflows/build-v3xctrl-arm64.yml
+++ b/.github/workflows/build-v3xctrl-arm64.yml
@@ -7,6 +7,10 @@ on:
         description: 'Git branch to build'
         required: true
         default: 'master'
+      version:
+        description: 'Package version (e.g. 1.0.0, 1.0.0-RC1). Leave empty for dev build.'
+        required: false
+        default: ''
 
 jobs:
   build-arm64-deb:
@@ -37,6 +41,19 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/releases/assets/$ASSET_ID \
             -o v3xctrl-python.deb
 
+      - name: Resolve dev version
+        if: ${{ !inputs.version }}
+        run: |
+          BASE_VERSION=$(grep '^Version:' build/packages/v3xctrl/DEBIAN/control | awk '{print $2}')
+          TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+          SHORT_HASH=$(git rev-parse --short HEAD)
+          echo "VERSION=${BASE_VERSION}~dev.${TIMESTAMP}.${SHORT_HASH}" >> $GITHUB_ENV
+
+      - name: Set explicit version
+        if: ${{ inputs.version }}
+        run: |
+          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+
       - name: Set up QEMU for ARM emulation
         uses: docker/setup-qemu-action@v4
         with:
@@ -55,6 +72,8 @@ jobs:
           outputs: type=local,dest=./build/out
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ env.VERSION }}
 
       - name: Upload built .deb package
         uses: actions/upload-artifact@v7

--- a/build/Dockerfiles/v3xctrl
+++ b/build/Dockerfiles/v3xctrl
@@ -1,6 +1,8 @@
 FROM arm64v8/debian:trixie
 
+ARG VERSION
 ENV DEBIAN_FRONTEND=noninteractive
+ENV VERSION=${VERSION}
 
 # Install base tools and deps for package build
 RUN apt-get update

--- a/build/build-in-chroot.sh
+++ b/build/build-in-chroot.sh
@@ -102,7 +102,14 @@ cp "./build/chroot/build-debs.sh" "${MOUNT_DIR}"
 chmod +x "${MOUNT_DIR}/build-debs.sh"
 
 echo "[HOST] Entering chroot and starting build"
-chroot "$MOUNT_DIR" bash -c "./build-debs.sh ${BUILD_PARAMS}"
+# Resolve version on the host where .git is available, pass it into the chroot
+if [ -z "${VERSION:-}" ]; then
+  BASE_VERSION=$(grep '^Version:' "./${PACKAGES_DIR}/v3xctrl/DEBIAN/control" | awk '{print $2}')
+  TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+  SHORT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  export VERSION="${BASE_VERSION}~dev.${TIMESTAMP}.${SHORT_HASH}"
+fi
+chroot "$MOUNT_DIR" bash -c "VERSION='${VERSION}' ./build-debs.sh ${BUILD_PARAMS}"
 
 echo "[HOST] Copying deb packages into place"
 cp ${MOUNT_DIR}/src/build/tmp/*.deb "${DEB_PATH}"

--- a/build/build-v3xctrl.sh
+++ b/build/build-v3xctrl.sh
@@ -54,6 +54,28 @@ mkdir -p "${PYTHON_LIB_PATH}"
 # Move files into place
 cp -r "${SRC_DIR}/" "$TMP_DIR"
 
+# Resolve package version
+# VERSION env var can be: "1.0.0", "1.0.0-RC1", or unset (dev build).
+# Converts to Debian-compatible versions using tilde for pre-release:
+#   1.0.0-RC1  -> 1.0.0~rc1
+#   1.0.0      -> 1.0.0
+#   (unset)    -> <base>~dev.<timestamp>.<hash>  (from DEBIAN/control + git)
+CONTROL_FILE="${DEST_DIR}/DEBIAN/control"
+BASE_VERSION=$(grep '^Version:' "${CONTROL_FILE}" | awk '{print $2}')
+
+if [ -n "${VERSION:-}" ]; then
+  # Explicit version: convert "1.0.0-RC1" to "1.0.0~rc1"
+  DEB_VERSION=$(echo "$VERSION" | sed 's/-\(.*\)/~\L\1/')
+else
+  # Dev build: append ~dev.<timestamp>.<short hash>
+  TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+  SHORT_HASH=$(git -C "${ROOT_DIR}" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+  DEB_VERSION="${BASE_VERSION}~dev.${TIMESTAMP}.${SHORT_HASH}"
+fi
+
+echo "[BUILD] Package version: ${DEB_VERSION}"
+sed -i "s/^Version: .*/Version: ${DEB_VERSION}/" "${CONTROL_FILE}"
+
 # Move python dependencies into place
 cp -r "${ROOT_DIR}/src/v3xctrl_control" "${PYTHON_LIB_PATH}"
 cp -r "${ROOT_DIR}/src/v3xctrl_gst" "${PYTHON_LIB_PATH}"


### PR DESCRIPTION
…d allow passing version from workflow

Merging this, there is not much to see here until it's deployed. When building locally, it will automatically set version like so:

```
[HOST] Entering chroot and starting build
[CHROOT] Building v3xctrl
[BUILD] Package version: 0.1.0~dev.20260427103835.53e84519
```

So in the future we will be able to easily update between package version without having to explicitly uninstall first.